### PR TITLE
Add Ethereum TSS simulator

### DIFF
--- a/examples/ethwallet/main.go
+++ b/examples/ethwallet/main.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"sync/atomic"
+
+	"github.com/bnb-chain/tss-lib/v2/common"
+	"github.com/bnb-chain/tss-lib/v2/ecdsa/keygen"
+	"github.com/bnb-chain/tss-lib/v2/ecdsa/signing"
+	"github.com/bnb-chain/tss-lib/v2/test"
+	"github.com/bnb-chain/tss-lib/v2/tss"
+)
+
+func runKeygen(participants, threshold int) ([]keygen.LocalPartySaveData, tss.SortedPartyIDs, error) {
+	pIDs := tss.GenerateTestPartyIDs(participants)
+	p2pCtx := tss.NewPeerContext(pIDs)
+
+	parties := make([]*keygen.LocalParty, 0, participants)
+	errCh := make(chan *tss.Error, participants)
+	outCh := make(chan tss.Message, participants)
+	endCh := make(chan *keygen.LocalPartySaveData, participants)
+
+	for i := 0; i < participants; i++ {
+		params := tss.NewParameters(tss.S256(), p2pCtx, pIDs[i], participants, threshold)
+		P := keygen.NewLocalParty(params, outCh, endCh).(*keygen.LocalParty)
+		parties = append(parties, P)
+		go func(P *keygen.LocalParty) {
+			if err := P.Start(); err != nil {
+				errCh <- err
+			}
+		}(P)
+	}
+
+	updater := test.SharedPartyUpdater
+
+	var ended int32
+	keys := make([]keygen.LocalPartySaveData, 0, participants)
+keygenLoop:
+	for {
+		select {
+		case err := <-errCh:
+			return nil, nil, fmt.Errorf("keygen error: %v", err)
+		case msg := <-outCh:
+			if dest := msg.GetTo(); dest == nil {
+				for _, P := range parties {
+					if P.PartyID().Index == msg.GetFrom().Index {
+						continue
+					}
+					go updater(P, msg, errCh)
+				}
+			} else {
+				go updater(parties[dest[0].Index], msg, errCh)
+			}
+		case save := <-endCh:
+			atomic.AddInt32(&ended, 1)
+			keys = append(keys, *save)
+			if atomic.LoadInt32(&ended) == int32(participants) {
+				break keygenLoop
+			}
+		}
+	}
+	// pIDs is already sorted by GenerateTestPartyIDs
+	return keys, pIDs, nil
+}
+
+func runSigning(keys []keygen.LocalPartySaveData, pIDs tss.SortedPartyIDs, msg []byte, threshold int) (*common.SignatureData, error) {
+	participants := len(keys)
+	p2pCtx := tss.NewPeerContext(pIDs)
+
+	parties := make([]*signing.LocalParty, 0, participants)
+	errCh := make(chan *tss.Error, participants)
+	outCh := make(chan tss.Message, participants)
+	endCh := make(chan *common.SignatureData, participants)
+
+	for i := 0; i < participants; i++ {
+		params := tss.NewParameters(tss.S256(), p2pCtx, pIDs[i], participants, threshold)
+		P := signing.NewLocalParty(new(big.Int).SetBytes(msg), params, keys[i], outCh, endCh).(*signing.LocalParty)
+		parties = append(parties, P)
+		go func(P *signing.LocalParty) {
+			if err := P.Start(); err != nil {
+				errCh <- err
+			}
+		}(P)
+	}
+
+	updater := test.SharedPartyUpdater
+
+	var ended int32
+	var sig *common.SignatureData
+signingLoop:
+	for {
+		select {
+		case err := <-errCh:
+			return nil, fmt.Errorf("signing error: %v", err)
+		case msg := <-outCh:
+			if dest := msg.GetTo(); dest == nil {
+				for _, P := range parties {
+					if P.PartyID().Index == msg.GetFrom().Index {
+						continue
+					}
+					go updater(P, msg, errCh)
+				}
+			} else {
+				go updater(parties[dest[0].Index], msg, errCh)
+			}
+		case sd := <-endCh:
+			atomic.AddInt32(&ended, 1)
+			sig = sd
+			if atomic.LoadInt32(&ended) == int32(threshold+1) {
+				break signingLoop
+			}
+		}
+	}
+	return sig, nil
+}
+
+func main() {
+	participants := 3
+	threshold := 1
+
+	keys, pids, err := runKeygen(participants, threshold)
+	if err != nil {
+		panic(err)
+	}
+
+	// Example message: hash of "hello eth"
+	h := sha256.Sum256([]byte("hello eth"))
+
+	sig, err := runSigning(keys, pids, h[:], threshold)
+	if err != nil {
+		panic(err)
+	}
+
+	r := new(big.Int).SetBytes(sig.R)
+	s := new(big.Int).SetBytes(sig.S)
+	fmt.Printf("Signature (r,s): %s %s\n", r.String(), s.String())
+
+	// Verify using standard ecdsa
+	pk := ecdsa.PublicKey{Curve: tss.S256(), X: keys[0].ECDSAPub.X(), Y: keys[0].ECDSAPub.Y()}
+	ok := ecdsa.Verify(&pk, h[:], r, s)
+	fmt.Printf("ECDSA Verify: %v\n", ok)
+
+	fmt.Printf("Signature hex r: %s\n", hex.EncodeToString(sig.R))
+	fmt.Printf("Signature hex s: %s\n", hex.EncodeToString(sig.S))
+}

--- a/examples/ethwalletsim/aggregator.go
+++ b/examples/ethwalletsim/aggregator.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"fmt"
+	"math/big"
+	"sync/atomic"
+
+	"github.com/bnb-chain/tss-lib/v2/common"
+	"github.com/bnb-chain/tss-lib/v2/ecdsa/keygen"
+	"github.com/bnb-chain/tss-lib/v2/ecdsa/signing"
+	"github.com/bnb-chain/tss-lib/v2/test"
+	"github.com/bnb-chain/tss-lib/v2/tss"
+)
+
+// Aggregator coordinates threshold key generation and signing among nodes.
+type Aggregator struct {
+	nodes     []*Node
+	pids      tss.SortedPartyIDs
+	threshold int
+}
+
+func NewAggregator(nodes []*Node, threshold int) *Aggregator {
+	return &Aggregator{nodes: nodes, threshold: threshold}
+}
+
+// KeyGen runs the distributed key generation protocol and stores the key shares
+// on each node.
+func (a *Aggregator) KeyGen() error {
+	participants := len(a.nodes)
+	pIDs := tss.GenerateTestPartyIDs(participants)
+	p2pCtx := tss.NewPeerContext(pIDs)
+
+	parties := make([]*keygen.LocalParty, participants)
+	errCh := make(chan *tss.Error, participants)
+	outCh := make(chan tss.Message, participants)
+	endCh := make(chan *keygen.LocalPartySaveData, participants)
+
+	for i := 0; i < participants; i++ {
+		params := tss.NewParameters(tss.S256(), p2pCtx, pIDs[i], participants, a.threshold)
+		parties[i] = keygen.NewLocalParty(params, outCh, endCh).(*keygen.LocalParty)
+		go func(p *keygen.LocalParty) {
+			if err := p.Start(); err != nil {
+				errCh <- err
+			}
+		}(parties[i])
+	}
+
+	updater := test.SharedPartyUpdater
+
+	var ended int32
+keygenLoop:
+	for {
+		select {
+		case err := <-errCh:
+			return fmt.Errorf("keygen error: %v", err)
+		case msg := <-outCh:
+			if dest := msg.GetTo(); dest == nil {
+				for _, p := range parties {
+					if p.PartyID().Index == msg.GetFrom().Index {
+						continue
+					}
+					go updater(p, msg, errCh)
+				}
+			} else {
+				go updater(parties[dest[0].Index], msg, errCh)
+			}
+		case save := <-endCh:
+			idx := -1
+			for i, id := range pIDs {
+				if id.KeyInt().Cmp(save.ShareID) == 0 {
+					idx = i
+					break
+				}
+			}
+			if idx < 0 {
+				return fmt.Errorf("unable to match save data to party id")
+			}
+			a.nodes[idx].data = *save
+			atomic.AddInt32(&ended, 1)
+			if atomic.LoadInt32(&ended) == int32(participants) {
+				a.pids = pIDs
+				break keygenLoop
+			}
+		}
+	}
+	return nil
+}
+
+// Sign runs the threshold signing protocol for the provided message bytes.
+func (a *Aggregator) Sign(msg []byte) (*common.SignatureData, error) {
+	participants := len(a.nodes)
+	p2pCtx := tss.NewPeerContext(a.pids)
+
+	parties := make([]*signing.LocalParty, participants)
+	errCh := make(chan *tss.Error, participants)
+	outCh := make(chan tss.Message, participants)
+	endCh := make(chan *common.SignatureData, participants)
+
+	for i := 0; i < participants; i++ {
+		params := tss.NewParameters(tss.S256(), p2pCtx, a.pids[i], participants, a.threshold)
+		parties[i] = signing.NewLocalParty(new(big.Int).SetBytes(msg), params, a.nodes[i].data, outCh, endCh).(*signing.LocalParty)
+		go func(p *signing.LocalParty) {
+			if err := p.Start(); err != nil {
+				errCh <- err
+			}
+		}(parties[i])
+	}
+
+	updater := test.SharedPartyUpdater
+
+	var ended int32
+	var sig *common.SignatureData
+signLoop:
+	for {
+		select {
+		case err := <-errCh:
+			return nil, fmt.Errorf("signing error: %v", err)
+		case msg := <-outCh:
+			if dest := msg.GetTo(); dest == nil {
+				for _, p := range parties {
+					if p.PartyID().Index == msg.GetFrom().Index {
+						continue
+					}
+					go updater(p, msg, errCh)
+				}
+			} else {
+				go updater(parties[dest[0].Index], msg, errCh)
+			}
+		case sd := <-endCh:
+			atomic.AddInt32(&ended, 1)
+			sig = sd
+			if atomic.LoadInt32(&ended) == int32(a.threshold+1) {
+				break signLoop
+			}
+		}
+	}
+	return sig, nil
+}

--- a/examples/ethwalletsim/main.go
+++ b/examples/ethwalletsim/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+
+	"github.com/bnb-chain/tss-lib/v2/tss"
+)
+
+func main() {
+	participants := 3
+	threshold := 1
+
+	nodes := make([]*Node, participants)
+	for i := 0; i < participants; i++ {
+		nodes[i] = NewNode(i)
+	}
+
+	agg := NewAggregator(nodes, threshold)
+
+	if err := agg.KeyGen(); err != nil {
+		panic(err)
+	}
+
+	msgHash := sha256.Sum256([]byte("hello eth"))
+
+	sig, err := agg.Sign(msgHash[:])
+	if err != nil {
+		panic(err)
+	}
+
+	r := new(big.Int).SetBytes(sig.R)
+	s := new(big.Int).SetBytes(sig.S)
+	fmt.Printf("Signature (r,s): %s %s\n", r.String(), s.String())
+
+	pk := ecdsa.PublicKey{Curve: tss.S256(), X: nodes[0].data.ECDSAPub.X(), Y: nodes[0].data.ECDSAPub.Y()}
+	ok := ecdsa.Verify(&pk, msgHash[:], r, s)
+	fmt.Printf("ECDSA Verify: %v\n", ok)
+	fmt.Printf("Signature hex r: %s\n", hex.EncodeToString(sig.R))
+	fmt.Printf("Signature hex s: %s\n", hex.EncodeToString(sig.S))
+}

--- a/examples/ethwalletsim/node.go
+++ b/examples/ethwalletsim/node.go
@@ -1,0 +1,17 @@
+package main
+
+import "github.com/bnb-chain/tss-lib/v2/ecdsa/keygen"
+
+// Node represents a participant holding a key share.
+type Node struct {
+	id   int
+	data keygen.LocalPartySaveData
+}
+
+func NewNode(id int) *Node {
+	return &Node{id: id}
+}
+
+func (n *Node) KeyData() keygen.LocalPartySaveData {
+	return n.data
+}


### PR DESCRIPTION
## Summary
- add `ethwalletsim` example with simulated nodes and aggregator
- demonstrate threshold key generation and signing for an Ethereum wallet

## Testing
- `go build ./examples/ethwallet`
- `go build ./examples/ethwalletsim`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6875054070f48328b6d3664ef157b775